### PR TITLE
Rename cookbook to devopsdance-nginx.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,6 +5,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  require_chef_omnibus: 12.19.36-1
 
 platforms:
   - name: ubuntu-14.04
@@ -25,5 +26,5 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[nginx::_tests]
+      - recipe[devopsdance-nginx::_tests]
 

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,11 +1,9 @@
 DEPENDENCIES
-  nginx
+  devopsdance-nginx
     path: .
     metadata: true
 
 GRAPH
-  apt (5.0.0)
-    compat_resource (>= 12.14.7)
-  compat_resource (12.16.2)
-  nginx (0.1.7)
+  apt (6.1.0)
+  devopsdance-nginx (1.0.0)
     apt (>= 0.0.0)

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,9 +1,9 @@
-name 'nginx'
+name 'devopsdance-nginx'
 maintainer 'DevopsDance'
 maintainer_email 'team@devops.dance'
-license 'All rights reserved'
+license 'Apache-2.0'
 description 'Installs and configures NGINX'
-version '0.1.7'
+version '1.0.0'
 source_url 'https://github.com/DevopsDance/chef-cookbook-nginx'
 issues_url 'https://github.com/DevopsDance/chef-cookbook-nginx/issues'
 

--- a/recipes/_tests.rb
+++ b/recipes/_tests.rb
@@ -1,4 +1,4 @@
-include_recipe 'nginx'
+include_recipe 'devopsdance-nginx'
 
 nginx_site 'tests' do
   action :enable

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,2 +1,2 @@
-include_recipe 'nginx::_install'
-include_recipe 'nginx::_conf'
+include_recipe 'devopsdance-nginx::_install'
+include_recipe 'devopsdance-nginx::_conf'

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -5,6 +5,8 @@
 #   action :create
 # end
 
+resource_name :nginx_conf
+
 default_action :create
 
 property :config, String, name_property: true

--- a/resources/module.rb
+++ b/resources/module.rb
@@ -8,6 +8,8 @@
 #   action :enable
 # end
 
+resource_name :nginx_module
+
 default_action :enable
 
 property :module_name, String, name_property: true

--- a/resources/site.rb
+++ b/resources/site.rb
@@ -9,6 +9,8 @@
 #   action :disable
 # end
 
+resource_name :nginx_site
+
 default_action :enable
 
 property :site_name, String, name_property: true


### PR DESCRIPTION
    This will prevent name collision with official nginx's cookbook.